### PR TITLE
Fix eval grad accumulation

### DIFF
--- a/ModelForge/evaluation/metrics.py
+++ b/ModelForge/evaluation/metrics.py
@@ -21,6 +21,10 @@ class MetricsCalculator:
         - Perplexity: exp(loss)
         - Loss: Cross-entropy loss
 
+        Note: When preprocess_logits_for_metrics is used, predictions contain
+        pre-computed scalar losses (one per eval batch) instead of full logit tensors.
+        This prevents RAM exhaustion during evaluation.
+
         Args:
             eval_pred: Evaluation prediction with predictions and labels
 
@@ -29,28 +33,16 @@ class MetricsCalculator:
         """
         logger.info("Computing causal LM metrics")
 
-        import torch
-        import torch.nn.functional as F
+        predictions = eval_pred.predictions
 
-        predictions, labels = eval_pred.predictions, eval_pred.label_ids
-
-        logits = torch.from_numpy(np.array(predictions)).float()
-        lbl = torch.from_numpy(np.array(labels))
-
-        shift_logits = logits[..., :-1, :].contiguous()
-        shift_labels = lbl[..., 1:].contiguous()
-
-        loss = F.cross_entropy(
-            shift_logits.view(-1, shift_logits.size(-1)),
-            shift_labels.view(-1).long(),
-            ignore_index=-100,
-            reduction="mean",
-        )
-        perplexity = float(torch.exp(loss))
+        # predictions is shape (num_eval_batches, 1) of pre-computed scalar losses
+        # (from _preprocess_logits_for_metrics in sft_strategy.py)
+        mean_loss = float(np.mean(predictions))
+        perplexity = float(np.exp(mean_loss))
 
         metrics = {
             "perplexity": perplexity,
-            "eval_loss": float(loss),
+            "eval_loss": mean_loss,
         }
 
         logger.info(f"Causal LM metrics: {metrics}")

--- a/ModelForge/services/training_service.py
+++ b/ModelForge/services/training_service.py
@@ -432,7 +432,16 @@ class TrainingService:
 
             # Train
             self.training_status["message"] = "Training in progress..."
-            trainer.train()
+            provider_name = config.get("provider", "")
+            if provider_name == "unsloth":
+                try:
+                    from unsloth import unsloth_train
+                    unsloth_train(trainer)
+                except ImportError:
+                    logger.warning("unsloth_train not available, falling back to trainer.train()")
+                    trainer.train()
+            else:
+                trainer.train()
 
             # Save model
             self.training_status["message"] = "Saving model..."

--- a/ModelForge/strategies/qlora_strategy.py
+++ b/ModelForge/strategies/qlora_strategy.py
@@ -22,6 +22,7 @@ except ImportError:
 from trl import SFTTrainer, SFTConfig
 
 from ..logging_config import logger
+from .sft_strategy import _preprocess_logits_for_metrics
 
 
 class QLoRAStrategy:
@@ -269,6 +270,7 @@ class QLoRAStrategy:
             peft_config=peft_config,
             callbacks=callbacks or [],
             compute_metrics=compute_metrics,
+            preprocess_logits_for_metrics=_preprocess_logits_for_metrics,
         )
 
         logger.info("QLoRA SFTTrainer created successfully")

--- a/ModelForge/strategies/sft_strategy.py
+++ b/ModelForge/strategies/sft_strategy.py
@@ -23,6 +23,37 @@ from trl import SFTTrainer, SFTConfig
 from ..logging_config import logger
 
 
+def _preprocess_logits_for_metrics(logits, labels):
+    """
+    Reduce logit tensors to scalar loss per batch before CPU accumulation.
+
+    This prevents RAM exhaustion when the Trainer accumulates eval predictions.
+    Instead of storing full logit tensors (batch × seq_len × vocab_size),
+    we compute the loss on GPU and return only a scalar, reducing memory by
+    orders of magnitude (e.g., 19.7 GB/batch → bytes/batch).
+
+    Args:
+        logits: Model logits (batch, seq_len, vocab_size)
+        labels: Token labels (batch, seq_len)
+
+    Returns:
+        Scalar loss tensor for this batch, shape (1,)
+    """
+    import torch.nn.functional as F
+
+    shift_logits = logits[..., :-1, :].contiguous()
+    shift_labels = labels[..., 1:].contiguous()
+
+    loss = F.cross_entropy(
+        shift_logits.view(-1, shift_logits.size(-1)),
+        shift_labels.view(-1).long(),
+        ignore_index=-100,
+        reduction="mean",
+    )
+
+    return loss.unsqueeze(0)
+
+
 class SFTStrategy:
     """Supervised Fine-Tuning strategy using TRL's SFTTrainer."""
 
@@ -248,6 +279,7 @@ class SFTStrategy:
             peft_config=peft_config,
             callbacks=callbacks or [],
             compute_metrics=compute_metrics,
+            preprocess_logits_for_metrics=_preprocess_logits_for_metrics,
         )
 
         logger.info("SFTTrainer created successfully")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "modelforge-finetuning"
-version = "3.0.4"
+version = "3.0.5"
 description = "ModelForge: A no-code toolkit for fine-tuning HuggingFace models"
 authors = [
     {name = "R3tr0 M1ll3r", email = "r3tr0.m1ll3r@gmail.com"},


### PR DESCRIPTION
This pull request introduces significant improvements to memory efficiency during evaluation and adds support for the Unsloth training provider. The main changes include implementing a mechanism to reduce RAM usage when storing evaluation logits, updating metric computation to work with pre-computed losses, and enabling Unsloth as a training backend. Additionally, the project version is incremented.

**Memory efficiency improvements for evaluation:**

* Added `_preprocess_logits_for_metrics` in `sft_strategy.py` to compute scalar loss per batch on GPU, drastically reducing RAM usage during evaluation. This function is now passed to both SFT and QLoRA trainers. [[1]](diffhunk://#diff-b0a4431a5b7ac57d287e5b1ead74dc66ed7713a031fbbcbd18d941f7da82d83eR26-R56) [[2]](diffhunk://#diff-b0a4431a5b7ac57d287e5b1ead74dc66ed7713a031fbbcbd18d941f7da82d83eR282) [[3]](diffhunk://#diff-0d475311f5f2fe926444c5c7b3b7ffe4ff6766c6b3d46ff2b12b36176ac3e428R25) [[4]](diffhunk://#diff-0d475311f5f2fe926444c5c7b3b7ffe4ff6766c6b3d46ff2b12b36176ac3e428R273)
* Updated `compute_causal_lm_metrics` in `metrics.py` to calculate metrics from pre-computed scalar losses instead of full logit tensors, preventing RAM exhaustion. [[1]](diffhunk://#diff-9c1fb12c16ef1e73b173e33cb24eee16a8d9af9adb20a2f8fe1674d579678333R24-R27) [[2]](diffhunk://#diff-9c1fb12c16ef1e73b173e33cb24eee16a8d9af9adb20a2f8fe1674d579678333L32-R45)

**Training provider support:**

* Added conditional logic in `training_service.py` to support Unsloth as a training provider, using `unsloth_train` when specified in the config.

**Version update:**

* Bumped project version from `3.0.4` to `3.0.5` in `pyproject.toml`.